### PR TITLE
Use an abstract namespace UDS on Linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ winapi = { version = "0.3", features = ["synchapi", "winnt", "errhandlingapi", "
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+nix = "0.19"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,28 +20,28 @@
 //! }
 //! ```
 
-
 extern crate failure;
-#[cfg(windows)]
-extern crate winapi;
-#[cfg(windows)]
-extern crate widestring;
 #[cfg(unix)]
 extern crate libc;
+extern crate nix;
+#[cfg(windows)]
+extern crate widestring;
+#[cfg(windows)]
+extern crate winapi;
 
 pub use self::inner::*;
 
 #[cfg(target_os = "windows")]
 mod inner {
-    use std::ptr;
     use failure::Error;
+    use std::ptr;
     use widestring::WideCString;
-    use winapi::um::winnt::HANDLE;
-    use winapi::um::synchapi::CreateMutexW;
     use winapi::shared::minwindef::DWORD;
-    use winapi::um::errhandlingapi::GetLastError;
     use winapi::shared::winerror::ERROR_ALREADY_EXISTS;
+    use winapi::um::errhandlingapi::GetLastError;
     use winapi::um::handleapi::CloseHandle;
+    use winapi::um::synchapi::CreateMutexW;
+    use winapi::um::winnt::HANDLE;
 
     /// A struct representing one running instance.
     pub struct SingleInstance {
@@ -77,48 +77,60 @@ mod inner {
 
 #[cfg(target_os = "linux")]
 mod inner {
-    use std::fs::File;
-    use std::path::Path;
-    use std::os::unix::io::AsRawFd;
     use failure::Error;
-    use libc::{flock, LOCK_EX, LOCK_NB, EWOULDBLOCK, __errno_location};
+    use nix::errno::Errno;
+    use nix::sys::socket::{self, UnixAddr};
+    use nix::unistd;
+    use std::os::unix::prelude::RawFd;
 
     /// A struct representing one running instance.
     pub struct SingleInstance {
-        _file: File,
-        is_single: bool,
+        maybe_sock: Option<RawFd>,
     }
 
     impl SingleInstance {
         /// Returns a new SingleInstance object.
         pub fn new(name: &str) -> Result<Self, Error> {
-            let path = Path::new(name);
-            let file = if path.exists() {
-                File::open(path)?
-            } else {
-                File::create(path)?
+            let addr = UnixAddr::new_abstract(name.as_bytes())?;
+            let sock = socket::socket(
+                socket::AddressFamily::Unix,
+                socket::SockType::Stream,
+                socket::SockFlag::empty(),
+                None,
+            )?;
+
+            let maybe_sock = match socket::bind(sock, &socket::SockAddr::Unix(addr)) {
+                Ok(()) => Some(sock),
+                Err(nix::Error::Sys(Errno::EADDRINUSE)) => None,
+                Err(e) => return Err(e.into()),
             };
-            unsafe {
-                let rc = flock(file.as_raw_fd(), LOCK_EX | LOCK_NB);
-                let is_single = rc == 0 || EWOULDBLOCK != *__errno_location();
-                Ok(Self { _file: file, is_single })
-            }
+
+            Ok(Self { maybe_sock })
         }
 
         /// Returns whether this instance is single.
         pub fn is_single(&self) -> bool {
-            self.is_single
+            self.maybe_sock.is_some()
+        }
+    }
+
+    impl Drop for SingleInstance {
+        fn drop(&mut self) {
+            if let Some(sock) = self.maybe_sock {
+                // Intentionally discard any close errors.
+                let _ = unistd::close(sock);
+            }
         }
     }
 }
 
 #[cfg(target_os = "macos")]
 mod inner {
-    use std::fs::File;
-    use std::path::Path;
-    use std::os::unix::io::AsRawFd;
     use failure::Error;
-    use libc::{flock, LOCK_EX, LOCK_NB, EWOULDBLOCK, __error};
+    use libc::{__error, flock, EWOULDBLOCK, LOCK_EX, LOCK_NB};
+    use std::fs::File;
+    use std::os::unix::io::AsRawFd;
+    use std::path::Path;
 
     /// A struct representing one running instance.
     pub struct SingleInstance {
@@ -138,7 +150,10 @@ mod inner {
             unsafe {
                 let rc = flock(file.as_raw_fd(), LOCK_EX | LOCK_NB);
                 let is_single = rc == 0 || EWOULDBLOCK != *__error();
-                Ok(Self { _file: file, is_single })
+                Ok(Self {
+                    _file: file,
+                    is_single,
+                })
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 extern crate failure;
 #[cfg(unix)]
 extern crate libc;
+#[cfg(unix)]
 extern crate nix;
 #[cfg(windows)]
 extern crate widestring;


### PR DESCRIPTION
Here's my attempt at #6.

The implementation carries an `Option<RawFd>` around with it, which corresponds to the underlying socket (if successfully acquired). I've gone ahead and implemented `Drop` as well, to make its semantics consistent with the other `SingleInstance` implementations (otherwise it would live for the entire process lifecycle, regardless of whether the "owning" object was dropped).

Let me know what you think.