### PR TITLE
Fixes for SingleInstance on Windows

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,10 @@ pub enum SingleInstanceError {
     #[cfg(target_os = "windows")]
     #[error("wide string null error")]
     Nul(#[from] widestring::NulError<widestring::WideChar>),
+
+    #[cfg(target_os = "windows")]
+    #[error("CreateMutex failed with error code {0}")]
+    MutexError(u32),
 }
 
 pub type Result<T> = std::result::Result<T, SingleInstanceError>;


### PR DESCRIPTION
This PR addresses the following issues:

* On Windows there is no check if `CreateMutex` call failed for other than "already exists" reason but the code assumes we are running a single instance in this case which could be incorrect. A better solution is to return an error to the caller.
* Added Send/Sync marker trait implementation so SingleInstance can be used in async contexts, issue #8.
