### PR TITLE
Refactored into common flock-based implementation for POSIX platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,10 @@ include = [
 
 [dependencies]
 thiserror = "1.0"
-widestring = "0.4.3"
 
 [target.'cfg(windows)'.dependencies]
+widestring = "0.4.3"
 winapi = { version = "0.3", features = ["synchapi", "winnt", "errhandlingapi", "winerror", "handleapi"] }
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
-nix = "0.19"
+nix = "0.22"

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ single-instance
 [![Crates.io](https://img.shields.io/crates/v/single-instance.svg)](https://crates.io/crates/single-instance)
 [![Build Status](https://travis-ci.org/WLBF/single-instance.svg?branch=master)](https://travis-ci.org/WLBF/single-instance)
 
-single-instance provides a single API to check if there are any other running instance. 
+single-instance provides an API to check if there are any other running instances of the same process.
 
 ## Detail
-On windows, init `SingleInstance` will create a mutex named by given `&str` then check error code by calling `GetLastError`. On linux init will bind abstract unix domain socket with given name . On macos, init will create or open a file which path is given `&str`, then call `flock` to apply an advisory lock on the open file.
+On Windows, `SingleInstance` attempts to create a named mutex and checks if it already exists.
+On POSIX platforms it creates or opens a file with a given path, then attempts to apply an advisory lock on the opened file.
 
 ```toml
 [dependencies]
@@ -24,10 +25,6 @@ fn main() {
     {
         let instance_a = SingleInstance::new("whatever").unwrap();
         assert!(instance_a.is_single());
-        let instance_b = SingleInstance::new("whatever").unwrap();
-        assert!(!instance_b.is_single());
     }
-    let instance_c = SingleInstance::new("whatever").unwrap();
-    assert!(instance_c.is_single());
 }
 ```

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,19 +2,15 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum SingleInstanceError {
-    #[cfg(target_os = "linux")]
-    #[error("new abstract addr error")]
-    Nix(#[from] nix::Error),
-
-    #[cfg(target_os = "macos")]
+    #[cfg(unix)]
     #[error("file open or create error")]
     Io(#[from] std::io::Error),
 
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     #[error("wide string null error")]
     Nul(#[from] widestring::NulError<widestring::WideChar>),
 
-    #[cfg(target_os = "windows")]
+    #[cfg(windows)]
     #[error("CreateMutex failed with error code {0}")]
     MutexError(u32),
 }


### PR DESCRIPTION
This PR implements a common flock-based solution for POSIX platforms as advised in different articles. We use this code in our product so I thought to make a PR into upstream.

The issue with Unix domain sockets is that there could be a stale socket file left on the filesystem which will cause the bind operation to fail. This situation is difficult to resolve correctly.
