### PR TITLE
added example for ensuring SingleInstance lock stays during lifetime of process and added docs

### DIFF
--- a/examples/multi_instance_server.rs
+++ b/examples/multi_instance_server.rs
@@ -1,0 +1,27 @@
+extern crate single_instance;
+use std::{thread::sleep, time::Duration};
+use single_instance::SingleInstance;
+
+static UNIQ_ID : &'static str = "multi_instance_server";
+static SLEEP_SECS : u64 = 100;
+
+/// Run in one terminal (this should be the first instance of this program) :
+///     cargo run --example multi_instance_server  
+/// 
+/// Run in another terminal(this should fail, provieded above program is still running) :
+///     cargo run --example multi_instance_server  
+fn main() { 
+    let instance =Box::new(SingleInstance::new(UNIQ_ID).unwrap());
+    
+    println!("server is single: {}\n", instance.is_single());
+    
+    if instance.is_single() {
+        Box::leak(instance);
+     
+        println!("Sleeping for secs:{}, press ^C for exit.
+Run another instance of the same process to see the single instance is false(within sleep seconds)", SLEEP_SECS);
+
+        sleep(Duration::from_secs(SLEEP_SECS));
+        // once is sleep is over, other proces can claim the single instance
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,14 +180,19 @@ mod inner {
     }
 }
 
-#[test]
-fn test_single_instance() {
-    {
-        let instance_a = SingleInstance::new("aa2d0258-ffe9-11e7-ba89-0ed5f89f718b").unwrap();
-        assert!(instance_a.is_single());
-        let instance_b = SingleInstance::new("aa2d0258-ffe9-11e7-ba89-0ed5f89f718b").unwrap();
-        assert!(!instance_b.is_single());
+#[cfg(test)]
+mod tests {
+    use super::*;
+    static UNIQ_ID : &'static str   = "aa2d0258-ffe9-11e7-ba89-0ed5f89f718b";
+    #[test]
+    fn test_single_instance() {
+        {
+            let instance_a = SingleInstance::new(UNIQ_ID).unwrap();
+            assert!(instance_a.is_single());
+            let instance_b = SingleInstance::new(UNIQ_ID).unwrap();
+            assert!(!instance_b.is_single());
+        }
+        let instance_c = SingleInstance::new(UNIQ_ID).unwrap();
+        assert!(instance_c.is_single());
     }
-    let instance_c = SingleInstance::new("aa2d0258-ffe9-11e7-ba89-0ed5f89f718b").unwrap();
-    assert!(instance_c.is_single());
 }


### PR DESCRIPTION
Added docs for keeping the instance of SingleInstance for the lifetime of process.
Also added example code to demonstrate the multiple process detect existence of another instance running